### PR TITLE
fix: parse JSON from AI response prose

### DIFF
--- a/uni-cal/src/outline-calander/utils/dataProcessor.js
+++ b/uni-cal/src/outline-calander/utils/dataProcessor.js
@@ -28,6 +28,37 @@ export function validateImportData(data) {
 
 
 /**
+ * Extract the first complete JSON array or object from an AI response.
+ * @param {string} aiMessage - Raw AI response text
+ * @returns {Object|Array|null} - Parsed JSON content, if one is present
+ */
+export function parseAIJSONResponse(aiMessage) {
+  const firstArray = aiMessage.indexOf('[');
+  const firstObject = aiMessage.indexOf('{');
+
+  const start = [firstArray, firstObject]
+    .filter(index => index !== -1)
+    .sort((a, b) => a - b)[0];
+
+  if (start === undefined) {
+    return null;
+  }
+
+  const endChar = aiMessage[start] === '[' ? ']' : '}';
+  const end = aiMessage.lastIndexOf(endChar);
+
+  if (end === -1 || end <= start) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(aiMessage.slice(start, end + 1));
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
  * Process PDF data and extract events from AI response
  * @param {Array} pdfData - Array of PDF info objects
  * @returns {Array} - Array of event objects with summary field
@@ -60,21 +91,16 @@ async function processPDFData(pdfData) {
     // Extract the actual message content from the API response
     if (responseData?.choices?.[0]?.message?.content) {
       const aiMessage = responseData.choices[0].message.content;
-      // Try to parse as JSON if it's a JSON response
-      try {
-        const parsedContent = JSON.parse(aiMessage);
+      const parsedContent = parseAIJSONResponse(aiMessage);
 
-        // If it's an array of events, return them
-        if (Array.isArray(parsedContent)) {
-          return parsedContent;
-        }
-        // If it's a single event object, wrap in array
-        if (parsedContent && typeof parsedContent === 'object') {
-          return [parsedContent];
-        }
-      } catch (e) {
-        console.log('AI response is not JSON, raw text:', aiMessage);
+      if (Array.isArray(parsedContent)) {
+        return parsedContent;
       }
+      if (parsedContent && typeof parsedContent === 'object') {
+        return [parsedContent];
+      }
+
+      console.log('AI response is not JSON, raw text:', aiMessage);
     } else {
       console.log('Unexpected response structure from OpenRouter API');
     }

--- a/uni-cal/src/outline-calander/utils/dataProcessor.test.js
+++ b/uni-cal/src/outline-calander/utils/dataProcessor.test.js
@@ -1,0 +1,25 @@
+import { parseAIJSONResponse } from './dataProcessor';
+
+describe('parseAIJSONResponse', () => {
+  it('parses a JSON array with leading and trailing prose', () => {
+    const response = `sure, here is the json:
+[
+  {"summary":"Midterm","description":"Exam"}
+]
+Thanks!`;
+
+    expect(parseAIJSONResponse(response)).toEqual([
+      { summary: 'Midterm', description: 'Exam' }
+    ]);
+  });
+
+  it('parses a JSON object with leading and trailing prose', () => {
+    const response = 'Here you go: {"summary":"Quiz"} done';
+
+    expect(parseAIJSONResponse(response)).toEqual({ summary: 'Quiz' });
+  });
+
+  it('returns null when no JSON payload is present', () => {
+    expect(parseAIJSONResponse('No events found')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem
LLM responses can include short prose before or after the JSON payload. The current parser calls `JSON.parse` on the entire message, so otherwise valid payloads are discarded when the model prefixes text like `sure, here is the json:`.

Fixes #77.

## Solution
- Added `parseAIJSONResponse` to extract the first complete JSON array or object from the AI message.
- Reused the existing array/object handling after parsing the cleaned payload.
- Added tests covering leading/trailing prose around arrays and objects, plus non-JSON responses.

## Validation
- `npm test -- --watchAll=false dataProcessor.test.js` (3 tests passed)
- `git diff --check`

Note: `npm ci` could not run because the existing lockfile is out of sync with `package.json` (missing `yaml@2.9.0`), so I used `npm install` only to install local test dependencies and did not include any lockfile changes.

## Confidence
92/100 — code fix for a directly reported good-first bug with targeted regression tests.